### PR TITLE
Endpoint returns invalid JSON

### DIFF
--- a/ratings.go
+++ b/ratings.go
@@ -83,7 +83,7 @@ func (s *SSE) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			log.Println("Done: Closed connection")
 			return
 		case msg := <-messages:
-			fmt.Fprintf(rw, "{\"data\": %s}\n\n", msg)
+			fmt.Fprintf(rw, "{\"data\": %s}\r\n", msg)
 			f.Flush()
 		}
 	}

--- a/ratings.go
+++ b/ratings.go
@@ -83,7 +83,7 @@ func (s *SSE) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			log.Println("Done: Closed connection")
 			return
 		case msg := <-messages:
-			fmt.Fprintf(rw, "data: %s\n\n", msg)
+			fmt.Fprintf(rw, "{\"data\": %s}\n\n", msg)
 			f.Flush()
 		}
 	}


### PR DESCRIPTION
The returned Json now matches the format specified in the Readme.

EDIT:
Apparently `\n\n` is causing an empty chunk interleaved with the actual data. At least this is what it seems when consuming the endpoint using Spring Boot's `WebClient` with Reactor and Netty.

The RFC-compliant way to send chunks is to end each chunk with a `\r\n` (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding#Directives). According to [this link](https://golang.org/src/net/http/httputil/httputil.go?s=1431:1480#L25), the framework should do this automatically, not sure why it's not happening.